### PR TITLE
Minor fixes to address build errors

### DIFF
--- a/rlimit.go
+++ b/rlimit.go
@@ -15,9 +15,9 @@ func getRlimitMax(resource int) int {
 
 	if err == nil {
 		return int(rlimit.Max)
-	} else {
-		return 0
 	}
+
+	return 0
 }
 
 func setRlimit(resource int, value int) {

--- a/tarpit.go
+++ b/tarpit.go
@@ -3,7 +3,6 @@ package main
 import (
 	"container/list"
 	"flag"
-	"log"
 	"math/rand"
 	"net"
 	"net/http"


### PR DESCRIPTION
Fixes errors during build:

rlimit.go:22: not enough arguments to return
tarpit.go:6: imported and not used: "log"
