### PR TITLE
Heroku support

### DIFF
--- a/.godir
+++ b/.godir
@@ -1,0 +1,1 @@
+github.com/die-net/http-tarpit

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: http-tarpit -listen=:$PORT

--- a/README.md
+++ b/README.md
@@ -61,3 +61,12 @@ even when idle.  If -timeslice isn't an even multiple of -period, you will
 get a slightly inaccurate -period.
 
 The workers count defaults to the number of CPUs you have in /proc/cpuinfo.
+
+Deploying to Heroku:
+-------------------
+
+To deploy a tarpit server to [Heroku](http://heroku.com), start with this [guide](http://mmcgrana.github.io/2012/09/getting-started-with-go-on-heroku.html).
+Assuming you have the Heroku command line tools installed, you can start with:
+
+	heroku create -b https://github.com/kr/heroku-buildpack-go.git
+	git push heroku master


### PR DESCRIPTION
This commit makes it possible to deploy the `http-tarpit` package directly to [Heroku](http://heroku.com), allowing a user to roll their own instant tarpit.

It adds two files, `.godir` and `Procfile`, required by Heroku and the Heroku [buildpack for Go](https://github.com/kr/heroku-buildpack-go). Their usage is described [here](https://mmcgrana.github.io/2012/09/getting-started-with-go-on-heroku.html). These files are otherwise ignored by the Go build process, retaining the use of `http-tarpit` as a standalone package.

We’ve deployed this into production at [Domainr](https://domainr.com) to fight API spammers. Thanks for making this possible!